### PR TITLE
UI 1: serve public and load dist/bundle.js in erb

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ $ bin/rails server
 
 Fields in db/payload:
 
+```
 {
     question: text,
     answer: text
 }
+```
 
 
 | Verb | Path | Payload | Description |

--- a/UI.md
+++ b/UI.md
@@ -1,0 +1,59 @@
+# Layout: application.html.erb
+
+This is the main layout used for the Rails app.
+The views go in the `yield` section inside `<body>`
+
+
+## For mobile-responsive, put this
+
+`<meta content="width=device-width, initial-scale=1" name="viewport" />` 
+
+
+# View: index.html.erb
+
+via `routes.rb` > `get 'welcome/index'` 
+
+We'll mount our React SPA here for now, since we probably won't need React in the other pages, like the CRUD Admin page
+
+
+# pages vs views
+
+Views are loaded inside the layout template (which has the head, body, scripts etc)
+
+Pages are independent, with its own head, body and scripts
+
+For now, we'll load the React app in the `index.html.erb` view,
+but if this will limit us, it might be better to have it in it's own page with a dedicated route
+(like in `react-rails` repo)
+
+
+# Asset Pipeline
+
+## `public` directory
+
+In previous Rails(before 5), all assets are in the subdirectories of `public/`, such as `images, javascripts, stylesheets`
+
+Any assets in `public/` will be served as static files by the app/web server when:
+
+```ruby
+config.public_file_server.enabled = true
+```
+
+> might have to do this both in production|developement.rb
+
+
+
+### WE'RE NOT USING IT IN THIS APP, but...
+
+With the new **Asset pipeline** the preferred location is in `app/assets` served by the `Sprockets` middleware
+
+Use `app/assets` for files that must undergo some pre-processsing before served, these files are never served directly in production
+
+Rails precompiles these to `public/assets` by default
+then server as static assets by the web server
+
+
+
+
+
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,9 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+    <%# mobile responsive %>
+    <meta content="width=device-width, initial-scale=1" name="viewport" />
   </head>
 
   <body>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,4 +1,12 @@
-<h1>Welcome#index</h1>
-<p>Find me in app/views/welcome/index.html.erb</p>
+<main>
+    <h1>React hello world!</h1>
+    <div id="react_app"></div>
+    <script src="dist/bundle.js"></script>
+</main>
+<hr />
+<footer>
+    <h1>Welcome#index</h1>
+    <p>Find me in app/views/welcome/index.html.erb</p>
 
-<%= link_to 'Lessons', controller: 'lessons' %>
+    <%= link_to 'Lessons', controller: 'lessons' %>
+</footer>

--- a/public/dist/bundle.js
+++ b/public/dist/bundle.js
@@ -1,0 +1,2 @@
+console.log("dist/bundle.js")
+console.log("THIS WILL BE SCRAPPED BY THE WEBPACK BUNDLE")


### PR DESCRIPTION
- serve dist/bundle.js

- Rails serve `public`
     - this is already enabled by default in
     - `config.public_file_server.enabled = true`

- Using a view instead of a page

    Views are loaded inside the layout template (which has the head, body, scripts etc)

    Pages are independent, with its own head, body and scripts

    For now, we'll load the React app in the `index.html.erb` view,

    but if this will limit us, it might be better to have it in it's own page with a dedicated route

    (like in `react-rails` repo)

- Serve `dist/bundle.js` 
     - without webpack for now, just verify being picked up by the view `index.html.erb`